### PR TITLE
Use custom implementation of fetch_multi for ActiveSupport NullStore

### DIFF
--- a/lib/perforated/compatibility/fetch_multi.rb
+++ b/lib/perforated/compatibility/fetch_multi.rb
@@ -24,8 +24,12 @@ module Perforated
     end
 
     def self.supports_fetch_multi?
-      Perforated.cache.respond_to?(:fetch_multi) &&
-      !Perforated.cache.instance_of?(ActiveSupport::Cache::MemoryStore)
+      cache = Perforated.cache
+
+      cache.respond_to?(:fetch_multi) && !(
+        cache.instance_of?(ActiveSupport::Cache::MemoryStore) ||
+        cache.instance_of?(ActiveSupport::Cache::NullStore)
+      )
     end
   end
 end


### PR DESCRIPTION
`ActiveSupport::Cache::NullStore#fetch_multi` returns an array instead of a hash in Rails 4.1.

This PR implements a fallback to the custom implementation of `fetch_multi` when using `NullStore`.
